### PR TITLE
Change Dockerfile to build system independent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,18 @@ WORKDIR /apic
 COPY . .
 
 # Install debug tools
-RUN apt-get update && apt-get -y install mtr \
-netcat \
-iproute2
+RUN apt-get update && apt-get install -y \
+  mtr \
+  netcat \
+  iproute2 \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install APIC
 RUN npm i -g apiconnect --unsafe
 
-# Expose port for APIC toolkit GUI
-EXPOSE 3000
+RUN npm install
 
-CMD ["echo", "apic toolkit container..."]
+# Expose port for APIC toolkit GUI
+EXPOSE 8080
+
 CMD [ "node", "test.js" ]

--- a/test.js
+++ b/test.js
@@ -118,7 +118,7 @@ app.get('/get/change', function (req, res) {
     res.send(`-----RESULT-----\nLogin attempt: ${stdout2.toString()}\n${stdout3.toString()}`)
 });
 
-var server = app.listen(3000, function () {
+var server = app.listen(8080, function () {
   var host = server.address().address;
   var port = server.address().port;
   var init = execSync('yes | apic -v')


### PR DESCRIPTION
Remove first `CMD` command as only one `CMD` is allowed in a Dockerfile.

Introduce `.dockerigonore` to avoid accidential pick-up of local files.

Add `.gitignore` with the same setup as `.dockerignore`.

Change default ports to 8080 as this is the CodeEngine default port. Otherwise
each application instance requires a CLI override to the specific port.

Add `apt-get` best practices for Dockerfiles by removing unnecessary files.

Add `npm install` to get dependencies during build.